### PR TITLE
Fix Traceback related to TypeError: tcsetattr

### DIFF
--- a/src/gitradar.py
+++ b/src/gitradar.py
@@ -275,7 +275,11 @@ def main():
     undef[0] = 'undefined'
     undef[3] = 'undefined'
     undef[4] = 'undefined'
-    screen.tty_signal_keys(undef)
+    
+    # Outcommenting tty_signal_keys call that fails with recent Python 3.8 urwid-2.1.1
+    #     TypeError: tcsetattr: elements of attributes must be characters or integers
+    #
+    # screen.tty_signal_keys(undef)
 
     main_frame = urwid.Frame(
         urwid.Filler(urwid.LineBox(grid_flow), valign="top"))


### PR DESCRIPTION
Fixing the following issue. The reason is still unknown.

Traceback (most recent call last):
  File "src/gitradar.py", line 297, in <module>
    main()
  File "src/gitradar.py", line 278, in main
    screen.tty_signal_keys(undef)
  File "/tools/gitradar/venv/lib/python3.8/site-packages/urwid-2.1.1-py3.8-linux-x86_64.egg/urwid/display_common.py", line 776, in tty_signal_keys
    termios.tcsetattr(fileno, termios.TCSADRAIN, tattr)
TypeError: tcsetattr: elements of attributes must be characters or integers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/softagram/gitradar/1)
<!-- Reviewable:end -->
